### PR TITLE
Getting the gem version out of the capistrano-rails-collection.rb file

### DIFF
--- a/capistrano-rails-collection.gemspec
+++ b/capistrano-rails-collection.gemspec
@@ -1,10 +1,11 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'capistrano-rails-collection'
 
 Gem::Specification.new do |spec|
   spec.name          = "capistrano-rails-collection"
-  spec.version       = "0.0.3"
+  spec.version       = CapistranoRailsCollection::VERSION
   spec.authors       = ["dei79"]
   spec.email         = ["dirk.eisenberg@gmail.com"]
   spec.description   = %q{Rails specific Capistrano tasks which are not part of the official rails gem}

--- a/lib/capistrano-rails-collection.rb
+++ b/lib/capistrano-rails-collection.rb
@@ -1,0 +1,3 @@
+module CapistranoRailsCollection
+  VERSION = '0.0.3'
+end


### PR DESCRIPTION
Since this file is blank, might as well use it to bump the version though there, that way the gemspec doesn't get touched 