### PR TITLE
db:create task added

### DIFF
--- a/lib/capistrano/tasks/db.rake
+++ b/lib/capistrano/tasks/db.rake
@@ -69,6 +69,17 @@ namespace :rails do
           end
         end
       end
+
+      desc 'Creates a database as mentioned in database.yml'
+      task :create do
+        on primary :db do
+          within release_path do
+            with rails_env: fetch(:stage) do
+              execute :rake, 'db:create'
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Useful when we need to manually recreate a database at a later point in developement.